### PR TITLE
Add attack signature for TCP Wrappers refusals.

### DIFF
--- a/src/common/attack.h
+++ b/src/common/attack.h
@@ -26,6 +26,7 @@
 
 enum service {
     SERVICES_ALL            = 0,    //< anything
+    SERVICES_LIBWRAP        = 10,   //< anything that uses TCP Wrapper
     SERVICES_SSH            = 100,  //< ssh
     SERVICES_SSHGUARD       = 110,  //< SSHGuard
     SERVICES_BIND           = 120,  //< BIND (named)

--- a/src/parser/attack_parser.y
+++ b/src/parser/attack_parser.y
@@ -119,6 +119,8 @@ static void yyerror(attack_t *, const char *);
 %token OPENVPN_PS_TERM_SUFF
 /* MSSQL */
 %token MSSQL_AUTHFAIL_PREF
+/* TCP Wrappers */
+%token LIBWRAP_REFUSE
 
 %%
 
@@ -195,6 +197,7 @@ msg_single:
   | giteamsg          { attack->service = SERVICES_GITEA; }
   | openvpnpsmsg      { attack->service = SERVICES_OPENVPN_PS; }
   | sqlservrmsg       { attack->service = SERVICES_MSSQL; }
+  | libwrapmsg        { attack->service = SERVICES_LIBWRAP; }
   ;
 
 /* an address */
@@ -388,6 +391,12 @@ sqlservrmsg:
 openvpnpsmsg:
     OPENVPN_PS_TERM_PREF addr OPENVPN_PS_TERM_SUFF
   | OPENVPN_PS_TERM_PREF '[' addr ']' OPENVPN_PS_TERM_SUFF
+  ;
+
+libwrapmsg:
+    LIBWRAP_REFUSE addr '(' IPv4 ')'
+  | LIBWRAP_REFUSE addr '(' IPv6 ')'
+  | LIBWRAP_REFUSE addr '(' HOSTADDR ')'
   ;
 
 %%

--- a/src/parser/attack_scanner.l
+++ b/src/parser/attack_scanner.l
@@ -344,6 +344,9 @@ HTTP_LOGIN_200OK_BAD       .*({WORDPRESS_LOGIN}|{TYPO3_LOGIN}|{CONTAO_LOGIN}).*
 "Login failed. The login is from an untrusted domain and cannot be used with Integrated authentication. [CLIENT: " { return MSSQL_AUTHFAIL_PREF; }
 "Length specified in network packet payload did not match number of bytes read; the connection has been closed. Please contact the vendor of the client library. [CLIENT: " { return MSSQL_AUTHFAIL_PREF; }
 
+ /* TCP Wrappers */
+"refused connect from " { return LIBWRAP_REFUSE; }
+
  /**         COMMON-USE TOKENS       do not touch these          **/
  /* an IPv4 address */
 {IPV4}                                                          { yylval.str = yytext; return IPv4; }

--- a/src/parser/tests.txt
+++ b/src/parser/tests.txt
@@ -1,3 +1,16 @@
+#### TCP Wrappers
+refused connect from 1.2.3.4 (1.2.3.4)
+10 1.2.3.4 4 10
+M
+refused connect from 1.2.3.4 (sample.com)
+10 1.2.3.4 4 10
+M
+refused connect from 2001:db8::a11:beef:7ac1 (2001:db8::a11:beef:7ac1)
+10 2001:db8::a11:beef:7ac1 6 10
+M
+refused connect from 2001:db8::a11:beef:7ac1 (sample.com)
+10 2001:db8::a11:beef:7ac1 6 10
+M
 #### SSH
 Invalid user inexu from 6.6.6.0
 100 6.6.6.0 4 10


### PR DESCRIPTION
Don't confuse to the TCP Wrappers "firewall" backend! This is not about adding matched hosts into /etc/hosts.allow, this is about adding to pf/ipfw a host that is already in /etc/hosts.allow but keeps knocking into the closed door and spamming the logs.