### PR TITLE
Update sshguard.conf.sample

### DIFF
--- a/examples/sshguard.conf.sample
+++ b/examples/sshguard.conf.sample
@@ -23,7 +23,7 @@
 THRESHOLD=30
 
 # Block attackers for initially BLOCK_TIME seconds after exceeding THRESHOLD.
-# Subsequent blocks increase by a factor of 1.5. (optional, default 120)
+# Subsequent blocks increase by a factor of 2. (optional, default 120)
 BLOCK_TIME=120
 
 # Remember potential attackers for up to DETECTION_TIME seconds before


### PR DESCRIPTION
based on this section of code the increasing factor is 2:
```c
/* compute blocking time wrt the "offensiveness" */
for (unsigned int i = 0; i < offenderent->numhits - 1; i++) {
    tmpent->pardontime *= 2;
}
```
but in the comments of `sshguard.conf.sample` it was stated that:
```
# Subsequent blocks increase by a factor of 1.5. (optional, default 120)
```
It also may be a good option to set increasing factor in config.