### PR TITLE
Add option to set subsequent block increasing factor by user

### DIFF
--- a/examples/sshguard.conf.sample
+++ b/examples/sshguard.conf.sample
@@ -23,7 +23,7 @@
 THRESHOLD=30
 
 # Block attackers for initially BLOCK_TIME seconds after exceeding THRESHOLD.
-# Subsequent blocks increase by a factor of 1.5. (optional, default 120)
+# Subsequent blocks increase by a factor of 2. (optional, default 120)
 BLOCK_TIME=120
 
 # Remember potential attackers for up to DETECTION_TIME seconds before

--- a/examples/sshguard.conf.sample
+++ b/examples/sshguard.conf.sample
@@ -22,8 +22,7 @@
 # Most attacks have a score of 10. (optional, default 30)
 THRESHOLD=30
 
-# Block attackers for initially BLOCK_TIME seconds after exceeding THRESHOLD.
-# Subsequent blocks increase by a factor of 2. (optional, default 120)
+# Block attackers for initially BLOCK_TIME seconds after exceeding THRESHOLD. (optional, default 120)
 BLOCK_TIME=120
 
 # Remember potential attackers for up to DETECTION_TIME seconds before
@@ -35,6 +34,9 @@ IPV6_SUBNET=128
 
 # Size of IPv4 subnet to block. Defaults to a single address, CIDR notation. (optional, default to 32)
 IPV4_SUBNET=32
+
+# Subsequent blocks increase by this factor. (optional, default 2)
+INCREASING_FACTOR=2
 
 # When set, sandboxed processes drop permissions by changing to this user.
 # (optional, no default)

--- a/src/blocker/blocker.c
+++ b/src/blocker/blocker.c
@@ -268,7 +268,7 @@ static void report_address(attack_t attack) {
         if (opts.blacklist_filename != NULL) {
             blacklist_add(offenderent);
         }
-    } else {
+    } else if (opts.increasing_factor > 1) {
         /* compute blocking time wrt the "offensiveness" */
         for (unsigned int i = 0; i < offenderent->numhits - 1; i++) {
             tmpent->pardontime *= opts.increasing_factor;

--- a/src/blocker/blocker.c
+++ b/src/blocker/blocker.c
@@ -271,7 +271,7 @@ static void report_address(attack_t attack) {
     } else {
         /* compute blocking time wrt the "offensiveness" */
         for (unsigned int i = 0; i < offenderent->numhits - 1; i++) {
-            tmpent->pardontime *= 2;
+            tmpent->pardontime *= opts.increasing_factor;
         }
     }
     list_sort(& offenders, -1);

--- a/src/blocker/sshguard_options.c
+++ b/src/blocker/sshguard_options.c
@@ -49,6 +49,7 @@ static void options_init(sshg_opts *opt) {
     opt->blacklist_filename = NULL;
     opt->subnet_ipv6 = 128;
     opt->subnet_ipv4 = 32;
+    opt->increasing_factor = 2;
 }
 
 int get_options_cmdline(int argc, char *argv[]) {
@@ -56,7 +57,7 @@ int get_options_cmdline(int argc, char *argv[]) {
 
     options_init(&opts);
 
-    while ((optch = getopt(argc, argv, "b:p:s:a:w:i:N:n:")) != -1) {
+    while ((optch = getopt(argc, argv, "b:p:s:a:w:i:N:n:f:")) != -1) {
         switch (optch) {
             case 'b':
                 opts.blacklist_filename = (char *)malloc(strlen(optarg) + 1);
@@ -113,6 +114,15 @@ int get_options_cmdline(int argc, char *argv[]) {
 
             case 'n':   /* IPv4 subnet size */
                 opts.subnet_ipv4 = strtol(optarg, (char **)NULL, 10);
+                break;
+
+            case 'f':   /* increasing factor */
+                opts.increasing_factor = strtof(optarg, (char **)NULL);
+                if (opts.increasing_factor < 1) {
+                    fprintf(stderr, "Doesn't make sense to have an increasing factor lower than 1. Terminating.\n");
+                    usage();
+                    return -1;
+                }
                 break;
 
             default:    /* or anything else: print help */

--- a/src/blocker/sshguard_options.h
+++ b/src/blocker/sshguard_options.h
@@ -29,6 +29,7 @@ typedef struct {
     char *blacklist_filename;           /* NULL to disable blacklist, or path of the blacklist file */
     unsigned int subnet_ipv6;           /* size of subnets to block, CIDR notation */
     unsigned int subnet_ipv4;           /* size of subnets to block, CIDR notation */
+    float increasing_factor             /* subsequent blocks increase by this factor */
 } sshg_opts;
 
 extern sshg_opts opts;

--- a/src/sshguard.in
+++ b/src/sshguard.in
@@ -18,9 +18,8 @@ usage() {
     cat << EOF
 Usage: sshguard [-v] [-h]
 [-a BLACKLIST-THRESHOLD] [-b BLACKLIST-FILE]
-[-i PID-FILE] [-p BLOCK_TIME]
+[-f INCREASING_FACTOR] [-i PID-FILE] [-p BLOCK_TIME]
 [-s DETECTION_TIME] [-w IP-ADDRESS | WHITELIST-FILE]
-[-f INCREASING_FACTOR]
 EOF
 }
 

--- a/src/sshguard.in
+++ b/src/sshguard.in
@@ -20,6 +20,7 @@ Usage: sshguard [-v] [-h]
 [-a BLACKLIST-THRESHOLD] [-b BLACKLIST-FILE]
 [-i PID-FILE] [-p BLOCK_TIME]
 [-s DETECTION_TIME] [-w IP-ADDRESS | WHITELIST-FILE]
+[-f INCREASING_FACTOR]
 EOF
 }
 
@@ -42,7 +43,7 @@ fi
 . $config
 
 # Runtime arguments override configuration options
-while getopts "b:l:p:s:a:w:i:hv" opt; do
+while getopts "b:l:p:s:a:w:i:f:hv" opt; do
     case $opt in
         a) THRESHOLD=$OPTARG;;
         b) BLACKLIST_FILE=$OPTARG;;
@@ -51,6 +52,7 @@ while getopts "b:l:p:s:a:w:i:hv" opt; do
         p) BLOCK_TIME=$OPTARG;;
         s) DETECTION_TIME=$OPTARG;;
         w) WHITELIST_ARG="$WHITELIST_ARG $OPTARG";;
+        f) INCREASING_FACTOR="$OPTARG";;
         h) usage; exit;;
         v) echo "SSHGuard $version"; exit;;
         *) echo "Try 'sshguard -h' for help"; exit 1;;
@@ -73,6 +75,7 @@ setflag 'p' "$BLOCK_TIME"
 setflag 's' "$DETECTION_TIME"
 setflag 'N' "$IPV6_SUBNET"
 setflag 'n' "$IPV4_SUBNET"
+setflag 'f' "$INCREASING_FACTOR"
 if [ -n "$WHITELIST_ARG" ]; then
     for arg in $WHITELIST_ARG; do
       flags="$flags -w $arg"


### PR DESCRIPTION
An option has been added to enable the user to set an increasing factor for subsequent blocking time. In some usage it may be useful for user to be able to set this factor based on the system requirements.

