### PR TITLE
Fix memory leak in parser

### DIFF
--- a/src/parser/Makefile.am
+++ b/src/parser/Makefile.am
@@ -19,4 +19,6 @@ sshg_parser_SOURCES = \
 	attack_parser.y \
 	attack_scanner.l \
 	parser.c \
-	parser.h
+	parser.h \
+	mem_tracker.c \
+	mem_tracker.h

--- a/src/parser/attack_parser.y
+++ b/src/parser/attack_parser.y
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "parser.h"
+#include "mem_tracker.h"
 
 #define DEFAULT_ATTACKS_DANGEROUSNESS           10
 
@@ -458,6 +459,7 @@ int parse_line(char *str, attack_t *attack) {
 
     scanner_init(str);
     int ret = yyparse(attack);
+    free_all_tracked();
     scanner_fin();
     if (attack->service == -1)
         return 1; // successful parse but no service (e.g. successful CLF)

--- a/src/parser/attack_scanner.l
+++ b/src/parser/attack_scanner.l
@@ -32,8 +32,6 @@
 %option nounput
 %option noyywrap
 
-%array
-
  /* Start Conditions */
  /* for Login services */
 %s ssh_notallowed ssh_reversemap ssh_disconnect ssh_badproto ssh_invalid_format ssh_badkex cockpit_authfail proxmoxve_authfail
@@ -343,15 +341,15 @@ HTTP_PATH                  "/"[^ ]+
 
  /**         COMMON-USE TOKENS       do not touch these          **/
  /* an IPv4 address */
-{IPV4}                                                          { yylval.str = yytext; return IPv4; }
-{IPV4MAPPED6}                                                   { yylval.str = strrchr(yytext, ':')+1; return IPv4; }
+{IPV4}                                                          { yylval.str = track_strdup(yytext); return IPv4; }
+{IPV4MAPPED6}                                                   { yylval.str = track_strdup(strrchr(yytext, ':') + 1); return IPv4; }
 
  /* an IPv6 address */
  /* standard | clouds implied | embedded IPv4 */
 {IPV6}                                                          { yylval.str = track_strdup(yytext); return IPv6; }
 
  /* an host address (PTR) */
-{HOSTADDR}                                                      { yylval.str = yytext; return HOSTADDR; }
+{HOSTADDR}                                                      { yylval.str = track_strdup(yytext); return HOSTADDR; }
 {NUMBER}                                                        { yylval.num = (int)strtol(yytext, (char **)NULL, 10); return INTEGER; }
  /* syslog timestamp */
  /*{MONTH}\ +{DAYNO}\ +{HOUR}:{MINPS}:{MINPS}                      { return TIMESTAMP_SYSLOG; }*/
@@ -367,7 +365,7 @@ HTTP_PATH                  "/"[^ ]+
 ": "[0-9]+" Time(s)"                                              return REPETITIONS;
 
  /*[^ :]+:[^ ]+                                                    { return FACILITYPRIORITY; } */
-{WORD}                                                          { yylval.str = yytext; return WORD; }
+{WORD}                                                          { yylval.str = track_strdup(yytext); return WORD; }
 
 "\""[^"]*"\"" { return STRING; }
 

--- a/src/parser/attack_scanner.l
+++ b/src/parser/attack_scanner.l
@@ -24,6 +24,7 @@
 
 #include "attack.h"
 #include "attack_parser.h"
+#include "mem_tracker.h"
 %}
 
 %option debug
@@ -347,7 +348,7 @@ HTTP_PATH                  "/"[^ ]+
 
  /* an IPv6 address */
  /* standard | clouds implied | embedded IPv4 */
-{IPV6}                                                          { yylval.str = strdup(yytext); return IPv6; }
+{IPV6}                                                          { yylval.str = track_strdup(yytext); return IPv6; }
 
  /* an host address (PTR) */
 {HOSTADDR}                                                      { yylval.str = yytext; return HOSTADDR; }

--- a/src/parser/mem_tracker.c
+++ b/src/parser/mem_tracker.c
@@ -1,0 +1,48 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "mem_tracker.h"
+
+typedef struct mem_block {
+    void *ptr;
+    struct mem_block *next;
+} mem_block_t;
+
+static mem_block_t *tracking_list_head = NULL;
+
+char *track_strdup(const char *str) {
+    if (!str)
+        return NULL;
+
+    char *new_str = strdup(str);
+    if (!new_str) {
+        perror("strdup()");
+        exit(1);
+    }
+
+    mem_block_t *block = malloc(sizeof(*block));
+    if (!block) {
+        perror("malloc()");
+        free(new_str);
+        exit(1);
+    }
+
+    block->ptr = new_str;
+    block->next = tracking_list_head;
+    tracking_list_head = block;
+
+    return new_str;
+}
+
+void free_all_tracked(void) {
+    mem_block_t *current = tracking_list_head;
+    while (current) {
+        mem_block_t *next = current->next;
+        free(current->ptr);
+        free(current);
+        current = next;
+    }
+
+    tracking_list_head = NULL;
+}

--- a/src/parser/mem_tracker.h
+++ b/src/parser/mem_tracker.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Mehran Hashemi <mehranstock1383@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * SSHGuard. See http://www.sshguard.net
+ */
+
+#pragma once
+
+/**
+ * @brief A replacement for strdup that also tracks the allocated pointer.
+ */
+char *track_strdup(const char *str);
+
+/**
+ * @brief Frees all pointers in the tracking list.
+ * Call this after `yyparse()` completes.
+ */
+void free_all_tracked(void);


### PR DESCRIPTION
This PR fixes a memory leak in the parser and includes a couple of related improvements:

- Because it is easy to forget that the string in `yytext` will be there only until the next token is scanned, it is recommended to make a copy of the strings to put into the symbol table entry.
- The lexer no longer uses `%array`, which only added unnecessary memory copy overhead. We rely on the default `%pointer` mode instead, which is more efficient.