### PR TITLE
Introduce small time library based on clock_gettime

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,9 @@
 SUBDIRS = blocker fw parser
 
 EXTRA_DIST = sshguard.in
-noinst_HEADERS = common/address.h common/attack.h common/metrics.h common/sandbox.h common/simclist.h
+noinst_HEADERS = common/address.h common/attack.h \
+		 common/metrics.h common/sandbox.h \
+		 common/simclist.h common/monotime.h
 
 dist_libexec_SCRIPTS = sshg-logtail
 sbin_SCRIPTS = sshguard

--- a/src/blocker/attack.c
+++ b/src/blocker/attack.c
@@ -1,13 +1,12 @@
 #include <assert.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
-#include <time.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 
 #include "attack.h"
+#include "monotime.h"
 #include "sshguard_options.h"
 
 int attackt_whenlast_comparator(const void *a, const void *b) {
@@ -22,7 +21,7 @@ void attackerinit(attacker_t *restrict ipe,
     strcpy(ipe->attack.address.value, attack->address.value);
     ipe->attack.address.kind = attack->address.kind;
     ipe->attack.service = attack->service;
-    ipe->whenfirst = ipe->whenlast = time(NULL);
+    ipe->whenfirst = ipe->whenlast = monotime();
     ipe->numhits = 1;
     ipe->cumulated_danger = attack->dangerousness;
 }

--- a/src/blocker/blocker.c
+++ b/src/blocker/blocker.c
@@ -23,10 +23,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <time.h>
 #include <unistd.h>
 
 #include "address.h"
@@ -34,6 +31,7 @@
 #include "blocklist.h"
 #include "sandbox.h"
 #include "simclist.h"
+#include "monotime.h"
 #include "sshguard_blacklist.h"
 #include "sshguard_log.h"
 #include "sshguard_options.h"
@@ -245,7 +243,7 @@ static void report_address(attack_t attack) {
         list_append(&limbo, tmpent);
     } else {
         /* otherwise, the entry was already existing, update with new data */
-        tmpent->whenlast = time(NULL);
+        tmpent->whenlast = monotime();
         tmpent->numhits++;
         tmpent->cumulated_danger += attack.dangerousness;
     }
@@ -309,10 +307,9 @@ static void report_address(attack_t attack) {
 
 static void purge_limbo_stale(void) {
     sshguard_log(LOG_DEBUG, "Purging old attackers.");
-    time_t now = time(NULL);
     for (unsigned int pos = 0; pos < list_size(&limbo); pos++) {
         attacker_t *tmpent = list_get_at(&limbo, pos);
-        if (now - tmpent->whenfirst > opts.stale_threshold) {
+        if (monotime_since(tmpent->whenfirst) > opts.stale_threshold) {
             list_delete_at(&limbo, pos);
             free(tmpent);
             pos--;

--- a/src/blocker/blocklist.c
+++ b/src/blocker/blocklist.c
@@ -1,11 +1,10 @@
 #include <assert.h>
 #include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 
 #include "blocklist.h"
 #include "simclist.h"
+#include "monotime.h"
 #include "sshguard_blacklist.h"
 #include "sshguard_log.h"
 #include "sshguard_options.h"
@@ -42,8 +41,8 @@ static void fw_release(const attack_t *attack) {
 
 static void unblock_expired() {
     attacker_t *tmpel;
+    time_t elapsed_time;
     int ret;
-    time_t now = time(NULL);
 
     pthread_testcancel();
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &ret);
@@ -55,11 +54,12 @@ static void unblock_expired() {
         if (tmpel->pardontime == 0)
             continue;
         /* process hosts with finite pardon time */
-        if (now - tmpel->whenlast > tmpel->pardontime) {
+        elapsed_time = monotime_since(tmpel->whenlast);
+        if (elapsed_time > tmpel->pardontime) {
             /* pardon time passed, release block */
             sshguard_log(LOG_NOTICE, "%s: unblocking after %lld secs",
                          tmpel->attack.address.value,
-                         (long long)(now - tmpel->whenlast));
+                         (long long)(elapsed_time));
             fw_release(&tmpel->attack);
             list_delete_at(&hell, pos);
             free(tmpel);

--- a/src/common/monotime.h
+++ b/src/common/monotime.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Mehran Hashemi <mehranstock1383@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static inline time_t monotime(void) {
+    struct timespec ts;
+    int ret;
+
+#ifdef CLOCK_BOOTTIME
+    ret = clock_gettime(CLOCK_BOOTTIME, &ts);
+#else
+    ret = clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
+
+    if (ret == -1) {
+        perror("clock_gettime");
+        exit(EXIT_FAILURE);
+    }
+
+    return ts.tv_sec;
+}
+
+static inline time_t monotime_since(time_t ref) {
+    return monotime() - ref;
+}


### PR DESCRIPTION
Replace usage of `time(NULL)` with `clock_gettime()`. This provides elapsed time since boot and avoids issues caused by wall‑clock adjustments.