### PR TITLE
Restore OpenSMTPD attack detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@ un-deprecated, contact the project mailing list.
 
 .. contents::
 
+Unreleased
+==========
+**Fixed**
+
+- Restore OpenSMTPD attack detection. Modern OpenSMTPD (>= late 2018)
+  no longer logs the source IP on the ``failed-command`` line; the
+  parser now correlates ``smtp connected`` and AUTH 535 ``failed-command``
+  lines by session id.
+
 2.5.1
 =====
 **Fixed**

--- a/src/parser/Makefile.am
+++ b/src/parser/Makefile.am
@@ -19,4 +19,6 @@ sshg_parser_SOURCES = \
 	attack_parser.y \
 	attack_scanner.l \
 	parser.c \
-	parser.h
+	parser.h \
+	sessmap.c \
+	sessmap.h

--- a/src/parser/attack_parser.y
+++ b/src/parser/attack_parser.y
@@ -113,9 +113,9 @@ static void yyerror(attack_t *, const char *);
  * it when the production aborts before its action runs free($1). Each
  * action also assigns $1 = NULL after free to prevent the destructor from
  * double-freeing if YYABORT fires from inside the action itself. */
-%token <str> OPENSMTPD_CONNECT_PREF OPENSMTPD_DISCONNECT_PREF OPENSMTPD_AUTHFAIL_PREF
-%token OPENSMTPD_CONNECT_SUFF OPENSMTPD_DISCONNECT_SUFF OPENSMTPD_AUTHFAIL_SUFF
-%destructor { free($$); } OPENSMTPD_CONNECT_PREF OPENSMTPD_DISCONNECT_PREF OPENSMTPD_AUTHFAIL_PREF
+%token <str> OPENSMTPD_CONNECT_PREF OPENSMTPD_DISCONNECT_PREF OPENSMTPD_FAILED_CMD_PREF
+%token OPENSMTPD_CONNECT_SUFF OPENSMTPD_DISCONNECT_SUFF OPENSMTPD_AUTHFAIL_SUFF OPENSMTPD_UNSUPPORTED_CMD_SUFF
+%destructor { free($$); } OPENSMTPD_CONNECT_PREF OPENSMTPD_DISCONNECT_PREF OPENSMTPD_FAILED_CMD_PREF
 /* courier */
 %token COURIER_AUTHFAIL_PREF
 /* OpenVPN */
@@ -415,7 +415,15 @@ opensmtpdmsg:
         { sessmap_put(SERVICES_OPENSMTPD, $1, &attack->address); free($1); $1 = NULL; }
   | OPENSMTPD_DISCONNECT_PREF OPENSMTPD_DISCONNECT_SUFF
         { sessmap_del(SERVICES_OPENSMTPD, $1); free($1); $1 = NULL; }
-  | OPENSMTPD_AUTHFAIL_PREF OPENSMTPD_AUTHFAIL_SUFF
+  | OPENSMTPD_FAILED_CMD_PREF OPENSMTPD_AUTHFAIL_SUFF
+        {
+            bool found = sessmap_get(SERVICES_OPENSMTPD, $1, &attack->address);
+            free($1);
+            $1 = NULL;
+            if (!found) YYABORT;
+            attack->service = SERVICES_OPENSMTPD;
+        }
+  | OPENSMTPD_FAILED_CMD_PREF OPENSMTPD_UNSUPPORTED_CMD_SUFF
         {
             bool found = sessmap_get(SERVICES_OPENSMTPD, $1, &attack->address);
             free($1);

--- a/src/parser/attack_parser.y
+++ b/src/parser/attack_parser.y
@@ -20,9 +20,11 @@
  * SSHGuard. See http://www.sshguard.net
  */
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "parser.h"
+#include "sessmap.h"
 
 #define DEFAULT_ATTACKS_DANGEROUSNESS           10
 
@@ -107,8 +109,13 @@ static void yyerror(attack_t *, const char *);
 %token CLF_WEB_PROBE
 /* CLF, common CMS frameworks brute-force attacks */
 %token CLF_CMS_LOGIN
-/* OpenSMTPD */
-%token OPENSMTPD_FAILED_CMD_PREF OPENSMTPD_AUTHFAIL_SUFF OPENSMTPD_UNSUPPORTED_CMD_SUFF
+/* OpenSMTPD: PREF tokens carry a strdup'd session id. The destructor frees
+ * it when the production aborts before its action runs free($1). Each
+ * action also assigns $1 = NULL after free to prevent the destructor from
+ * double-freeing if YYABORT fires from inside the action itself. */
+%token <str> OPENSMTPD_CONNECT_PREF OPENSMTPD_DISCONNECT_PREF OPENSMTPD_AUTHFAIL_PREF
+%token OPENSMTPD_CONNECT_SUFF OPENSMTPD_DISCONNECT_SUFF OPENSMTPD_AUTHFAIL_SUFF
+%destructor { free($$); } OPENSMTPD_CONNECT_PREF OPENSMTPD_DISCONNECT_PREF OPENSMTPD_AUTHFAIL_PREF
 /* courier */
 %token COURIER_AUTHFAIL_PREF
 /* OpenVPN */
@@ -189,7 +196,7 @@ msg_single:
   | vsftpdmsg         { attack->service = SERVICES_VSFTPD; }
   | cockpitmsg        { attack->service = SERVICES_COCKPIT; }
   | clfmsg
-  | opensmtpdmsg      { attack->service = SERVICES_OPENSMTPD; }
+  | opensmtpdmsg      /* service is set inside the rule only for AUTH failures */
   | couriermsg        { attack->service = SERVICES_COURIER; }
   | openvpnmsg        { attack->service = SERVICES_OPENVPN; }
   | giteamsg          { attack->service = SERVICES_GITEA; }
@@ -396,10 +403,26 @@ clfbytes: INTEGER | clffield;
 
 // }}}
 
-/* opensmtpd */
+/* opensmtpd
+ *
+ * OpenSMTPD logs only carry the source IP on the per-session 'connected'
+ * line. We index addresses by session id; the AUTH 535 production then
+ * looks the address up. Lines whose session was never seen (parser started
+ * mid-stream) are silently dropped via YYABORT.
+ */
 opensmtpdmsg:
-    OPENSMTPD_FAILED_CMD_PREF addr OPENSMTPD_AUTHFAIL_SUFF
-  | OPENSMTPD_FAILED_CMD_PREF addr OPENSMTPD_UNSUPPORTED_CMD_SUFF
+    OPENSMTPD_CONNECT_PREF addr OPENSMTPD_CONNECT_SUFF
+        { sessmap_put(SERVICES_OPENSMTPD, $1, &attack->address); free($1); $1 = NULL; }
+  | OPENSMTPD_DISCONNECT_PREF OPENSMTPD_DISCONNECT_SUFF
+        { sessmap_del(SERVICES_OPENSMTPD, $1); free($1); $1 = NULL; }
+  | OPENSMTPD_AUTHFAIL_PREF OPENSMTPD_AUTHFAIL_SUFF
+        {
+            bool found = sessmap_get(SERVICES_OPENSMTPD, $1, &attack->address);
+            free($1);
+            $1 = NULL;
+            if (!found) YYABORT;
+            attack->service = SERVICES_OPENSMTPD;
+        }
   ;
 
 /* attack rules for courier imap/pop */

--- a/src/parser/attack_scanner.l
+++ b/src/parser/attack_scanner.l
@@ -40,7 +40,7 @@
 %s sshguard_attack sshguard_block
 %s bind
  /* for Mail services */
-%s dovecot_loginerr cyrusimap_loginerr exim_esmtp_autherr exim_esmtp_loginerr sendmail_relaydenied sendmail_authfailure postfix_loginerr postfix_nonsmtp postfix_greylist opensmtpd_failedcmd postscreen
+%s dovecot_loginerr cyrusimap_loginerr exim_esmtp_autherr exim_esmtp_loginerr sendmail_relaydenied sendmail_authfailure postfix_loginerr postfix_nonsmtp postfix_greylist opensmtpd_connected opensmtpd_disconnected opensmtpd_failedauth postscreen
  /* for FTP services */
 %s freebsdftpd_loginerr  proftpd_loginerr  pureftpd_loginerr vsftpd_loginerr
  /* for git services */
@@ -300,12 +300,19 @@ HTTP_PATH                  "/"[^ ]+
 
  /* }}} */
 
- /* OpenSMTPD. */
- /* Unsupported command when attempting to log in. */
-[a-z0-9]+" smtp event=failed-command address="                  { BEGIN(opensmtpd_failedcmd); return OPENSMTPD_FAILED_CMD_PREF; }
-<opensmtpd_failedcmd>"host="{HOSTNAME}" command=\"".+"\" result=\"503 5.5.1 Invalid command: Command not supported\"" { BEGIN(INITIAL); return OPENSMTPD_UNSUPPORTED_CMD_SUFF; }
- /* Bad credentials */
-<opensmtpd_failedcmd>"host="{HOSTNAME}" command=\"AUTH ".+"\" result=\"535 Authentication failed\"" { BEGIN(INITIAL); return OPENSMTPD_AUTHFAIL_SUFF; }
+ /* OpenSMTPD.
+  * Modern OpenSMTPD (>= late 2018) does not log the source IP on the
+  * failed-command line. The IP only appears once per session on the
+  * 'smtp connected' line; subsequent events reference the same session id.
+  * We track sid -> address in a small in-process map (see sessmap.[ch])
+  * and resolve the address at the moment of an AUTH 535 failure.
+  */
+[0-9a-f]{16}" smtp connected address="                          { yylval.str = strndup(yytext, 16); BEGIN(opensmtpd_connected); return OPENSMTPD_CONNECT_PREF; }
+<opensmtpd_connected>" host=".+                                 { BEGIN(INITIAL); return OPENSMTPD_CONNECT_SUFF; }
+[0-9a-f]{16}" smtp disconnected"                                { yylval.str = strndup(yytext, 16); BEGIN(opensmtpd_disconnected); return OPENSMTPD_DISCONNECT_PREF; }
+<opensmtpd_disconnected>" reason=".+                            { BEGIN(INITIAL); return OPENSMTPD_DISCONNECT_SUFF; }
+[0-9a-f]{16}" smtp failed-command command=\"AUTH "              { yylval.str = strndup(yytext, 16); BEGIN(opensmtpd_failedauth); return OPENSMTPD_AUTHFAIL_PREF; }
+<opensmtpd_failedauth>[^\"]*"\" result=\"535 "[^\"]*"\""        { BEGIN(INITIAL); return OPENSMTPD_AUTHFAIL_SUFF; }
 
  /* pfSense web configurator */
 {HTTP_PATH}": webConfigurator authentication error for user '".+"' from: " { return PFSENSE_AUTH_FAIL; }

--- a/src/parser/attack_scanner.l
+++ b/src/parser/attack_scanner.l
@@ -40,7 +40,7 @@
 %s sshguard_attack sshguard_block
 %s bind
  /* for Mail services */
-%s dovecot_loginerr cyrusimap_loginerr exim_esmtp_autherr exim_esmtp_loginerr sendmail_relaydenied sendmail_authfailure postfix_loginerr postfix_nonsmtp postfix_greylist opensmtpd_connected opensmtpd_disconnected opensmtpd_failedauth postscreen
+%s dovecot_loginerr cyrusimap_loginerr exim_esmtp_autherr exim_esmtp_loginerr sendmail_relaydenied sendmail_authfailure postfix_loginerr postfix_nonsmtp postfix_greylist opensmtpd_connected opensmtpd_disconnected opensmtpd_failedcmd postscreen
  /* for FTP services */
 %s freebsdftpd_loginerr  proftpd_loginerr  pureftpd_loginerr vsftpd_loginerr
  /* for git services */
@@ -305,14 +305,18 @@ HTTP_PATH                  "/"[^ ]+
   * failed-command line. The IP only appears once per session on the
   * 'smtp connected' line; subsequent events reference the same session id.
   * We track sid -> address in a small in-process map (see sessmap.[ch])
-  * and resolve the address at the moment of an AUTH 535 failure.
+  * and resolve the address at the moment a failed-command is matched:
+  * either AUTH 535 (credential brute-force) or any command with the
+  * 503 "Command not supported" reply (probing for unadvertised AUTH /
+  * STARTTLS endpoints).
   */
 [0-9a-f]{16}" smtp connected address="                          { yylval.str = strndup(yytext, 16); BEGIN(opensmtpd_connected); return OPENSMTPD_CONNECT_PREF; }
 <opensmtpd_connected>" host=".+                                 { BEGIN(INITIAL); return OPENSMTPD_CONNECT_SUFF; }
 [0-9a-f]{16}" smtp disconnected"                                { yylval.str = strndup(yytext, 16); BEGIN(opensmtpd_disconnected); return OPENSMTPD_DISCONNECT_PREF; }
 <opensmtpd_disconnected>" reason=".+                            { BEGIN(INITIAL); return OPENSMTPD_DISCONNECT_SUFF; }
-[0-9a-f]{16}" smtp failed-command command=\"AUTH "              { yylval.str = strndup(yytext, 16); BEGIN(opensmtpd_failedauth); return OPENSMTPD_AUTHFAIL_PREF; }
-<opensmtpd_failedauth>[^\"]*"\" result=\"535 "[^\"]*"\""        { BEGIN(INITIAL); return OPENSMTPD_AUTHFAIL_SUFF; }
+[0-9a-f]{16}" smtp failed-command command=\""                   { yylval.str = strndup(yytext, 16); BEGIN(opensmtpd_failedcmd); return OPENSMTPD_FAILED_CMD_PREF; }
+<opensmtpd_failedcmd>"AUTH "[^\"]*"\" result=\"535 Authentication failed\""    { BEGIN(INITIAL); return OPENSMTPD_AUTHFAIL_SUFF; }
+<opensmtpd_failedcmd>[^\"]*"\" result=\"503 5.5.1 Invalid command: Command not supported\""    { BEGIN(INITIAL); return OPENSMTPD_UNSUPPORTED_CMD_SUFF; }
 
  /* pfSense web configurator */
 {HTTP_PATH}": webConfigurator authentication error for user '".+"' from: " { return PFSENSE_AUTH_FAIL; }

--- a/src/parser/sessmap.c
+++ b/src/parser/sessmap.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Ilya Voronin <ivoronin@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "sessmap.h"
+
+#include <stddef.h>
+#include <string.h>
+#include <time.h>
+
+#define SESSMAP_SIZE 128
+#define SESSMAP_TTL_SECONDS 3600
+#define SESSMAP_SID_LEN 16
+
+struct slot {
+    enum service service;
+    char sid[SESSMAP_SID_LEN + 1];
+    sshg_address_t addr;
+    time_t inserted_at;
+};
+
+static struct slot table[SESSMAP_SIZE];
+
+static bool slot_matches(const struct slot *s, enum service service, const char *sid) {
+    return s->sid[0] != '\0' && s->service == service && strcmp(s->sid, sid) == 0;
+}
+
+static struct slot *find_slot(enum service service, const char *sid) {
+    for (size_t i = 0; i < SESSMAP_SIZE; i++) {
+        if (slot_matches(&table[i], service, sid)) {
+            return &table[i];
+        }
+    }
+    return NULL;
+}
+
+static struct slot *find_empty_or_oldest(void) {
+    struct slot *oldest = &table[0];
+    for (size_t i = 0; i < SESSMAP_SIZE; i++) {
+        if (table[i].sid[0] == '\0') {
+            return &table[i];
+        }
+        if (table[i].inserted_at < oldest->inserted_at) {
+            oldest = &table[i];
+        }
+    }
+    return oldest;
+}
+
+void sessmap_put(enum service service, const char *sid, const sshg_address_t *addr) {
+    struct slot *s = find_slot(service, sid);
+    if (s == NULL) {
+        s = find_empty_or_oldest();
+    }
+    s->service = service;
+    memcpy(s->sid, sid, SESSMAP_SID_LEN);
+    s->sid[SESSMAP_SID_LEN] = '\0';
+    s->addr = *addr;
+    s->inserted_at = time(NULL);
+}
+
+bool sessmap_get(enum service service, const char *sid, sshg_address_t *out) {
+    struct slot *s = find_slot(service, sid);
+    if (s == NULL) {
+        return false;
+    }
+    if (time(NULL) - s->inserted_at > SESSMAP_TTL_SECONDS) {
+        s->sid[0] = '\0';
+        return false;
+    }
+    *out = s->addr;
+    return true;
+}
+
+void sessmap_del(enum service service, const char *sid) {
+    struct slot *s = find_slot(service, sid);
+    if (s != NULL) {
+        s->sid[0] = '\0';
+    }
+}

--- a/src/parser/sessmap.h
+++ b/src/parser/sessmap.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Ilya Voronin <ivoronin@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "address.h"
+#include "attack.h"
+
+/*
+ * Per-service session table: maps a (service, sid) pair to a source address.
+ * Used when a service splits the IP and the auth-failure event across
+ * multiple log lines correlated by a session id (e.g. modern OpenSMTPD).
+ * The service code keeps session ids from different services in separate
+ * namespaces so a string collision between two services does not matter.
+ */
+void sessmap_put(enum service service, const char *sid, const sshg_address_t *addr);
+bool sessmap_get(enum service service, const char *sid, sshg_address_t *out);
+void sessmap_del(enum service service, const char *sid);

--- a/src/parser/tests.txt
+++ b/src/parser/tests.txt
@@ -371,11 +371,59 @@ M
 # }}}
 
 # OpenSMTPD {{{
-38dd06274cde1fd7 smtp event=failed-command address=185.236.202.133 host=no-mans-land.m247.com command="AUTH LOGIN" result="503 5.5.1 Invalid command: Command not supported"
-270 185.236.202.133 4 10
+# Modern (>= late 2018) format: the IP is only logged on the per-session
+# 'connected' line. AUTH 535 failures cite the session id, and the parser
+# resolves the IP via an in-process session map.
+#
+# Real fixture: probing 'Mail from' before STARTTLS (530, not an attack)
+May 12 08:41:24 ruby smtpd[70918]: ad40ed229a392cee smtp connected address=158.94.210.138 host=<unknown>
+*
 M
-45addba89269aeaa smtp event=failed-command address=128.237.183.69 host=zeta.wv.cc.cmu.edu command="AUTH PLAIN (...)" result="535 Authentication failed"
-270 128.237.183.69 4 10
+May 12 08:41:26 ruby smtpd[70918]: ad40ed229a392cee smtp failed-command command="Mail from:<spameri@tiscali.it>" result="530 5.5.1 Invalid command: Must issue a STARTTLS command first"
+*
+M
+May 12 08:41:28 ruby smtpd[70918]: ad40ed229a392cee smtp disconnected reason=quit
+*
+M
+# Real fixture: AUTH LOGIN 535 attack with intermediate tls/authentication chatter
+May 12 08:41:59 ruby smtpd[70918]: ad40ed23873926e3 smtp connected address=81.30.98.207 host=<unknown>
+*
+M
+May 12 08:41:59 ruby smtpd[70918]: ad40ed23873926e3 smtp tls ciphers=TLSv1.2:ECDHE-RSA-AES256-GCM-SHA384:256
+*
+M
+May 12 08:41:59 ruby smtpd[70918]: ad40ed23873926e3 smtp authentication user=newlife result=permfail
+*
+M
+May 12 08:42:00 ruby smtpd[70918]: ad40ed23873926e3 smtp failed-command command="AUTH LOGIN (password)" result="535 Authentication failed"
+270 81.30.98.207 4 10
+M
+May 12 08:42:00 ruby smtpd[70918]: ad40ed23873926e3 smtp disconnected reason=disconnect
+*
+M
+# AUTH PLAIN variant + IPv6
+1111222233334444 smtp connected address=2001:db8::1 host=v6.example
+*
+M
+1111222233334444 smtp failed-command command="AUTH PLAIN (...)" result="535 Authentication failed"
+270 2001:db8::1 6 10
+M
+1111222233334444 smtp disconnected reason=quit
+*
+M
+# AUTH LOGIN (username) phase
+abcdefabcdefabcd smtp connected address=10.0.0.5 host=foo.example
+*
+M
+abcdefabcdefabcd smtp failed-command command="AUTH LOGIN (username)" result="535 Authentication failed"
+270 10.0.0.5 4 10
+M
+abcdefabcdefabcd smtp disconnected reason=quit
+*
+M
+# AUTH 535 without preceding 'connected' (parser started mid-stream) -> no attack
+beefcafebeefcafe smtp failed-command command="AUTH LOGIN (password)" result="535 Authentication failed"
+*
 M
 # }}}
 

--- a/src/parser/tests.txt
+++ b/src/parser/tests.txt
@@ -425,6 +425,36 @@ M
 beefcafebeefcafe smtp failed-command command="AUTH LOGIN (password)" result="535 Authentication failed"
 *
 M
+# 503 Command not supported - AUTH probe on server without AUTH advertised
+ad40ee0f12345678 smtp connected address=185.236.202.133 host=no-mans-land.m247.com
+*
+M
+ad40ee0f12345678 smtp failed-command command="AUTH LOGIN" result="503 5.5.1 Invalid command: Command not supported"
+270 185.236.202.133 4 10
+M
+ad40ee0f12345678 smtp disconnected reason=quit
+*
+M
+# 503 Command not supported - STARTTLS probe on non-TLS server
+fedcba9876543210 smtp connected address=10.0.0.99 host=foo.example
+*
+M
+fedcba9876543210 smtp failed-command command="STARTTLS" result="503 5.5.1 Invalid command: Command not supported"
+270 10.0.0.99 4 10
+M
+fedcba9876543210 smtp disconnected reason=quit
+*
+M
+# Negative: other 503 variants must NOT trigger
+1234567890abcdef smtp connected address=10.0.0.50 host=bar.example
+*
+M
+1234567890abcdef smtp failed-command command="RCPT TO:<a@b.c>" result="503 5.5.1 Invalid command: Command not allowed at this point."
+*
+M
+1234567890abcdef smtp disconnected reason=quit
+*
+M
 # }}}
 
 # cyrus {{{


### PR DESCRIPTION
## Why

OpenSMTPD stopped logging the source IP on per-event lines in late 2018 (openbsd/src commits e40448f5, 79f63b05 - dropped `event=` prefix and `address=`/`host=` fields). Since then the sshguard signature at `attack_scanner.l:303-308` has matched nothing, and OpenSMTPD attacks have been silently undetected for ~7 years.

Modern OpenSMTPD logs an AUTH 535 failure as just:

```
<sessid> smtp failed-command command="AUTH LOGIN (password)" result="535 Authentication failed"
```

The IP only appears once per session on the `smtp connected` line:

```
<sessid> smtp connected address=<ip> host=<unknown>
```

## How

Introduce `src/parser/sessmap.{c,h}`: a flat 128-slot session-id → IP table inside `sshg-parser`, populated on `smtp connected`, cleared on `smtp disconnected`, with a 1-hour TTL backstop. Three new bison productions wire the per-line scanner tokens to put/get/del on the map; AUTH 535 resolves the source IP from the map and emits the standard `service addr kind danger` tuple.

Composite (service, sid) keys are used so the table is reusable if any other service ever needs the same pattern.